### PR TITLE
feat: group-join function handles IDs sent from app

### DIFF
--- a/src/rapidpro-shared-data/group-join/README.md
+++ b/src/rapidpro-shared-data/group-join/README.md
@@ -4,6 +4,13 @@ This function is used to enable syncing data between rapidpro and app shared-dat
 
 It specifically enables rapidpro users to join the group via their rapidpro uuid, and sync contact data to shared
 
+## Interaction Pathways
+
+There are two ways to interact with this function (`groupJoin`):
+
+- From RapidPro: RapidPro calls the `groupJoin` HTTPS endpoint with an `access_code` plus the sender's `rapidpro_uuid` and `rapidpro_fields`. The function records the parent using the RapidPro UUID.
+- From an app: your application calls the same `groupJoin` HTTPS endpoint using an `access_code` plus an app identity (`auth_user_id` when authenticated, otherwise `app_user_id`). If the endpoint lives in a different Firebase project, call `groupJoinProxy` instead (it forwards the request to the upstream `groupJoin`).
+
 ![alt text](image.png)
 
 ## TODOs

--- a/src/rapidpro-shared-data/group-join/group-join.test.ts
+++ b/src/rapidpro-shared-data/group-join/group-join.test.ts
@@ -97,7 +97,6 @@ describe("groupJoin HTTP Validation", () => {
         details: {
           _errors: [],
           access_code: { _errors: ["Required"] },
-          rapidpro_uuid: { _errors: ["Required"] },
           rapidpro_fields: { _errors: ["Required"] },
         },
       },

--- a/src/rapidpro-shared-data/group-join/group-join.ts
+++ b/src/rapidpro-shared-data/group-join/group-join.ts
@@ -16,11 +16,11 @@ if (admin.apps.length === 0) {
 const PARAMS_SCHEMA = z.object({
   access_code: z.string(),
   rapidpro_uuid: z.string().uuid().optional(),
-  app_parent_id: z.string().optional(),
-  app_auth_parent_id: z.string().optional(),
+  app_user_id: z.string().optional(),
+  auth_user_id: z.string().optional(),
   rapidpro_fields: z.record(z.any()),
 }).refine(
-  (data) => !!(data.rapidpro_uuid || data.app_auth_parent_id || data.app_parent_id),
+  (data) => !!(data.rapidpro_uuid || data.auth_user_id || data.app_user_id),
   {
     message: "At least one ID is required",
     path: [],
@@ -78,8 +78,8 @@ async function addParentToGroup(params: IGroupJoinRequestParams, response: Respo
     access_code,
     rapidpro_fields,
     rapidpro_uuid,
-    app_auth_parent_id,
-    app_parent_id,
+    auth_user_id,
+    app_user_id,
   } = params;
 
   const ref = admin.firestore().collection("shared_data");
@@ -103,8 +103,8 @@ async function addParentToGroup(params: IGroupJoinRequestParams, response: Respo
   const parents = data.parentGroupData?.parents;
   const idInfo = getPriorityParentId({
     rapidpro_uuid,
-    app_auth_parent_id,
-    app_parent_id,
+    auth_user_id,
+    app_user_id,
   });
   const userId = idInfo.value;
 
@@ -121,8 +121,8 @@ async function addParentToGroup(params: IGroupJoinRequestParams, response: Respo
   parents.push({
     rapidpro_fields,
     ...(rapidpro_uuid ? { rapidpro_uuid } : {}),
-    ...(app_auth_parent_id ? { app_auth_parent_id } : {}),
-    ...(app_parent_id ? { app_parent_id } : {}),
+    ...(auth_user_id ? { auth_user_id } : {}),
+    ...(app_user_id ? { app_user_id } : {}),
   });
   data.parentGroupData.parents = parents;
   try {
@@ -161,14 +161,14 @@ function sensitiveStringIsEqual(a: string, b: string) {
  */
 function getPriorityParentId(params: {
   rapidpro_uuid?: string;
-  app_auth_parent_id?: string;
-  app_parent_id?: string;
+  auth_user_id?: string;
+  app_user_id?: string;
 }) {
   if (params.rapidpro_uuid) {
     return { key: "rapidpro_uuid" as const, value: params.rapidpro_uuid };
   }
-  if (params.app_auth_parent_id) {
-    return { key: "app_auth_parent_id" as const, value: params.app_auth_parent_id };
+  if (params.auth_user_id) {
+    return { key: "auth_user_id" as const, value: params.auth_user_id };
   }
-  return { key: "app_parent_id" as const, value: params.app_parent_id as string };
+  return { key: "app_user_id" as const, value: params.app_user_id as string };
 }

--- a/src/rapidpro-shared-data/group-join/group-join.ts
+++ b/src/rapidpro-shared-data/group-join/group-join.ts
@@ -15,9 +15,17 @@ if (admin.apps.length === 0) {
 /** Request param schema and validation */
 const PARAMS_SCHEMA = z.object({
   access_code: z.string(),
-  rapidpro_uuid: z.string().uuid(),
+  rapidpro_uuid: z.string().uuid().optional(),
+  app_parent_id: z.string().optional(),
+  app_auth_parent_id: z.string().optional(),
   rapidpro_fields: z.record(z.any()),
-});
+}).refine(
+  (data) => !!(data.rapidpro_uuid || data.app_auth_parent_id || data.app_parent_id),
+  {
+    message: "At least one ID is required",
+    path: [],
+  },
+);
 
 // Generated type from schema validation above
 export type IGroupJoinRequestParams = z.infer<typeof PARAMS_SCHEMA>;
@@ -66,7 +74,13 @@ export type IFirestoreParentGroup = {
 
 /** Store reference to rapidpro parent within parentGroup data **/
 async function addParentToGroup(params: IGroupJoinRequestParams, response: Response) {
-  const { access_code, rapidpro_fields, rapidpro_uuid } = params;
+  const {
+    access_code,
+    rapidpro_fields,
+    rapidpro_uuid,
+    app_auth_parent_id,
+    app_parent_id,
+  } = params;
 
   const ref = admin.firestore().collection("shared_data");
   const { size, docs } = await ref.where("access_code", "==", access_code).get();
@@ -87,23 +101,34 @@ async function addParentToGroup(params: IGroupJoinRequestParams, response: Respo
     return errorResponse(response, "DATA_ERROR", msg);
   }
   const parents = data.parentGroupData?.parents;
+  const idInfo = getPriorityParentId({
+    rapidpro_uuid,
+    app_auth_parent_id,
+    app_parent_id,
+  });
+  const userId = idInfo.value;
 
   // Return success if user already member
-  const existingUser = parents.find((p) => p.rapidpro_uuid === rapidpro_uuid);
+  const existingUser = parents.find((p) => p[idInfo.key] === userId);
   if (existingUser) {
     return successResponse(response, "USER_EXISTING", {
-      userId: rapidpro_uuid,
+      userId,
       groupId: groupDoc.id,
       totalMembers: parents.length,
     });
   }
   // Add user to group and update
-  parents.push({ rapidpro_uuid, rapidpro_fields });
+  parents.push({
+    rapidpro_fields,
+    ...(rapidpro_uuid ? { rapidpro_uuid } : {}),
+    ...(app_auth_parent_id ? { app_auth_parent_id } : {}),
+    ...(app_parent_id ? { app_parent_id } : {}),
+  });
   data.parentGroupData.parents = parents;
   try {
     await groupDoc.ref.update({ data });
     return successResponse(response, "USER_ADDED", {
-      userId: rapidpro_uuid,
+      userId,
       groupId: groupDoc.id,
       totalMembers: parents.length,
     });
@@ -125,4 +150,25 @@ function sensitiveStringIsEqual(a: string, b: string) {
   const bBuffer = Buffer.from(b, "utf8");
   if (aBuffer.length !== bBuffer.length) return false;
   return timingSafeEqual(aBuffer, bBuffer);
+}
+
+/**
+ * Determine the parent ID to use for the user based on the available options
+ * Order of priority is:
+ * 1. Rapidpro UUID (included in requests from RapidPro)
+ * 2. App Auth Parent ID (included in requests from app, if user is authenticated)
+ * 3. App Parent ID (included in all requests from app)
+ */
+function getPriorityParentId(params: {
+  rapidpro_uuid?: string;
+  app_auth_parent_id?: string;
+  app_parent_id?: string;
+}) {
+  if (params.rapidpro_uuid) {
+    return { key: "rapidpro_uuid" as const, value: params.rapidpro_uuid };
+  }
+  if (params.app_auth_parent_id) {
+    return { key: "app_auth_parent_id" as const, value: params.app_auth_parent_id };
+  }
+  return { key: "app_parent_id" as const, value: params.app_parent_id as string };
 }


### PR DESCRIPTION
Updates the `groupJoin` function to handle requests sent from an app (as opposed to RapidPro), specifically by allowing alternative IDs. Previously, a `rapidpro_uuid` was required to be provided, now the payload can alternatively contain:
- `auth_user_id`
  - This will be sent from the app in the case that the app user is authenticated (which is optional)
- `app_user_id`
  - This will be sent from the app in all cases, but will only be used if `app_auth_parent_id` is not provided
  
These param names match those of "protected fields" within the app code (i.e. `@fields._app_user_id` and `@fields._auth_user_id`)